### PR TITLE
make the disassembler more flexible

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -206,6 +206,20 @@ Setting clear_sym=True also allows you to establish symbols prior to running the
         a.symbols['skyblue'] = 0x4500
         a.assemble(lines, clear_sym=FALSE)
 
+Getting hex dump format data in and out
+---------------------------------------
+After assembling you can output the object code as a hex dump with * marking the unpopulated spaces
+
+        >>> a.print_object_code()
+        >>> a.print_object_code(canonical=True)
+
+The second version used unix hexdump format, which includes an ASCII decode of printable characters.
+
+You can also load the object code map from files in this format, with an optional offset:
+
+        >>> a.load_object_code("some_file.txt", offset=0x400)
+
+
 Getting IntelHex format data out
 --------------------------------
 After assembling you can output the object code in intelhex format.

--- a/README.txt
+++ b/README.txt
@@ -215,7 +215,11 @@ After assembling you can output the object code as a hex dump with * marking the
 
 The second version used unix hexdump format, which includes an ASCII decode of printable characters.
 
-You can also load the object code map from files in this format, with an optional offset:
+An optional offset can be used to affect the address field in the output. For example, to generate data for a PROM programmer that expects the addresses to be relative to the first location in the ROM, choose an offset that causes the start address to wrap back to 0 like this:
+
+        >>> a.print_object_code(canonical=True, offset=-0xb400)
+
+You can also load the object code map from a file in hexdump format, also with an optional offset:
 
         >>> a.load_object_code("some_file.txt", offset=0x400)
 

--- a/src/asm6502.py
+++ b/src/asm6502.py
@@ -1,5 +1,8 @@
-import re
+#
+# The 65C02 Assembler
+#
 
+import re
 
 class asm6502():
     def __init__(self, debug=0):

--- a/src/asm6502.py
+++ b/src/asm6502.py
@@ -1295,12 +1295,17 @@ class asm6502():
 
         return (listingtext, symboltext)
 
-    def print_object_code(self, canonical=False):
+    def print_object_code(self, canonical=False, offset=0):
         """
         default format:
         0000: 1A 27 03 68 65 6C 6C 6F 08 AA 08 CC DD 3F 08 2D
         canonical=True format (matches unix hexdump):
         00000000  1a 27 03 68 65 6c 6c 6f  08 aa 08 cc dd 3f 08 2d  |...hello........|
+
+        offset can be used to affect the address field in the output (for example,
+        to generate data for a PROM programmer that expects the addresses to
+        be relative to the first location in the ROM, choose an offset that
+        causes the start address, considered as a 32-bit value, to wrap back to 0)
         """
         print("OBJECT CODE")
 
@@ -1315,11 +1320,11 @@ class asm6502():
             if self.object_code[i] != -1:
                 printed_a_star = 0
                 if canonical:
-                    astring = "%08x  %02x" % (i, self.object_code[i])
+                    astring = "%08x  %02x" % (0xffffffff & (offset + i), self.object_code[i])
                     ascii = "  |" + ('.' if self.object_code[i]<32 or self.object_code[i]>126 else chr(self.object_code[i]))
                     ascii_trail = "|"
                 else:
-                    astring = "%04X: %02X" % (i, self.object_code[i])
+                    astring = "%04X: %02X" % (0xffff & (offset + i), self.object_code[i])
                 localrun = 1
                 i = i + 1
                 if (i < 65536):

--- a/src/asm6502.py
+++ b/src/asm6502.py
@@ -1295,37 +1295,80 @@ class asm6502():
 
         return (listingtext, symboltext)
 
-    def print_object_code(self):
+    def print_object_code(self, canonical=False):
+        """
+        default format:
+        0000: 1A 27 03 68 65 6C 6C 6F 08 AA 08 CC DD 3F 08 2D
+        canonical=True format (matches unix hexdump):
+        00000000  1a 27 03 68 65 6c 6c 6f  08 aa 08 cc dd 3f 08 2d  |...hello........|
+        """
         print("OBJECT CODE")
 
         # Insert a star when there are empty spots in the memory map
         i = 0
         astring = ""
+        ascii = ""
+        ascii_trail = ""
         printed_a_star = 0
+        start_i = 0
         while (i < 65536):
             if self.object_code[i] != -1:
                 printed_a_star = 0
-                astring = "%04X: %02X" % (i, self.object_code[i])
+                if canonical:
+                    astring = "%08x  %02x" % (i, self.object_code[i])
+                    ascii = "  |" + ('.' if self.object_code[i]<32 or self.object_code[i]>126 else chr(self.object_code[i]))
+                    ascii_trail = "|"
+                else:
+                    astring = "%04X: %02X" % (i, self.object_code[i])
                 localrun = 1
                 i = i + 1
                 if (i < 65536):
                     nextval = self.object_code[i]
                     while (nextval != -1) and (localrun < 16):
-                        astring = astring + " %02X" % self.object_code[i]
+                        if canonical:
+                            astring = astring + " %02x" % self.object_code[i]
+                            ascii = ascii + ('.' if self.object_code[i]<32 or self.object_code[i]>126 else chr(self.object_code[i]))
+                            if localrun == 7:
+                                astring = astring + " "
+                        else:
+                            astring = astring + " %02X" % self.object_code[i]
                         i = i + 1
                         localrun = localrun + 1
                         if (i < 65536):
                             nextval = self.object_code[i]
                         else:
                             nextval = -1
-                    print(astring)
+                    print(astring + " " *3*(16-localrun) + " " *(localrun < 8) + ascii + ascii_trail)
                 else:
-                    print(astring)
+                    # corner case where 0xffff is defined but 0xfffe is not
+                    print(astring + " " *3*15 + " " + ascii + ascii_trail)
             else:
                 if (printed_a_star == 0):
                     print("*")
                     printed_a_star = 1
                 i = i + 1
+
+    def load_object_code(self, infile, offset=0):
+        """
+        Populate the object code map with data from infile, applying an optional
+        address offset. infile is in unix hexdump format: the address and data
+        information is used and the ASCII dump is ignored. No checking (eg for
+        address overlap) is performed.
+        """
+        with open(infile, 'r') as file:
+            for line in file:
+                parts = line.split()
+                addr = offset + int(parts.pop(0),16)
+                aoff = 0
+                # a stream of 8-bit values followed by ASCII decode, so rugged approach
+                # is to check for valid 2-character hex and break when we run out
+                for i in parts:
+                    val = re.match(r'[a-fA-F0-9][a-fA-F0-9]', i)
+                    if val:
+                        self.object_code[addr + aoff] = int(val[0],16)
+                        aoff = aoff + 1
+                    else:
+                        break
 
     def srecord_checksum(self, astring):
         checksum = 0

--- a/src/dis6502.py
+++ b/src/dis6502.py
@@ -373,7 +373,7 @@ class dis6502:
                 operandtext = "-$%02x" % offset
             length = 2
         elif addrmode == "accumulator":
-            operandtext = "A"
+            operandtext = "a"
             length = 1
         elif addrmode == "implicit":
             operandtext = ""

--- a/src/dis6502.py
+++ b/src/dis6502.py
@@ -11,15 +11,18 @@ class dis6502:
                 self.object_code[i] = 0x00
 
         self.labels = {}
-        if symbols == None:
-            self.have_symbols = False
-        else:
-            self.have_symbols = True
-
+        self.symbols = {}
+        if symbols:
             self.symbols = symbols
-            for label, offset in self.symbols.items():
-                self.labels[offset] = label
+
         self.build_opcode_table()
+        self.build_symbols_xref()
+
+
+    def build_symbols_xref(self):
+        self.labels = {};
+        for label, offset in self.symbols.items():
+            self.labels[offset] = label
 
     def build_opcode_table(self):
         self.hexcodes = dict()

--- a/src/dis6502.py
+++ b/src/dis6502.py
@@ -315,12 +315,6 @@ class dis6502:
 
         # print("DISASSEMBLER OPCD: %02x" % opcode_hex)
         # print("DISASSEMBLER OPCD TXT:"+str(opcode)+" "+str(addrmode))
-        if address in self.labels:
-            label = (self.labels[address] + ":").ljust(10)
-        else:
-            label = " " * 10
-
-        addr_text = "%04x " % address
 
         # Format the operand based on the addressmode
         length = 1
@@ -388,16 +382,19 @@ class dis6502:
             print("ERROR: Disassembler: Address mode %s not found" % addrmode)
             exit()
 
-        if length == 1:
-            binary_text = "%02x       " % opcode_hex
-        elif length == 2:
-            binary_text = "%02x %02x    " % (opcode_hex, operandl)
+        if address in self.labels:
+            label = self.labels[address] + ":"
         else:
-            binary_text = "%02x %02x %02x " % (opcode_hex, operandl, operandh)
+            label = ""
 
-        the_text = label + " " + addr_text + binary_text
-        the_text += (opcode.ljust(5))
-        the_text += operandtext
+        if length == 1:
+            operands = " " * 5
+        elif length == 2:
+            operands = f"{operandl:02x}   "
+        else:
+            operands = f"{operandl:02x} {operandh:02x}"
+
+        the_text = f"{label:11s}{address:04x} {opcode_hex:02x} {operands} {opcode:5s}{operandtext}"
         return (the_text, length)
 
     def disassemble_region(self, address, region_length):

--- a/src/dis6502.py
+++ b/src/dis6502.py
@@ -1,9 +1,6 @@
-#!/usr/bin/env python
-
 #
-# The 65C02 Simulator
+# The 65C02 Disassembler
 #
-
 
 class dis6502:
     def __init__(self, object_code, symbols=None):

--- a/src/dis6502.py
+++ b/src/dis6502.py
@@ -296,7 +296,7 @@ class dis6502:
         self.hexcodes[0xFF] = ("", "")
 
     def disassemble_line(self, address):
-        # print "DISASSEMBLER ADDR: %04x" % address
+        # print("DISASSEMBLER ADDR: %04x" % address)
         opcode_hex = self.object_code[address]
         operandl = self.object_code[(address + 1) % 65536]
         operandh = self.object_code[(address + 2) % 65536]
@@ -304,10 +304,17 @@ class dis6502:
         operand8 = operandl
         operand16 = operandl + (operandh << 8)
 
-        # print "OPCODE_HEX = %x" % opcode_hex
+        # print("OPCODE_HEX = %x" % opcode_hex)
         opcode, addrmode = self.hexcodes[opcode_hex]
-        # print "DISASSEMBLER OPCD: %02x" % opcode_hex
-        # print "DISASSMBLER OPCD TXT:"+str(opcode)+" "+str(addrmode)
+        # Undefined instructions
+        if opcode == "":
+            if opcode_hex > 32 and opcode_hex < 127:
+                opcode = f'db   ${opcode_hex:02X} ;"{chr(opcode_hex)}"'
+            else:
+                opcode = f'db   ${opcode_hex:02X}'
+
+        # print("DISASSEMBLER OPCD: %02x" % opcode_hex)
+        # print("DISASSEMBLER OPCD TXT:"+str(opcode)+" "+str(addrmode))
         if address in self.labels:
             label = (self.labels[address] + ":").ljust(10)
         else:

--- a/src/sim6502.py
+++ b/src/sim6502.py
@@ -1,3 +1,7 @@
+#
+# The 65C02 Simulator
+#
+
 import memory_map
 
 class Flags(object):
@@ -13,9 +17,6 @@ class Flags(object):
 
 # TODO: check for other cases of % on negative numbers leading to negative underflow
 
-#
-# The 65C02 Simulator
-#
 class sim6502(object):
     def __init__(self, object_code=None, address=0x0, symbols=None):
         self.pc = 0x0000

--- a/src/small_dis_example.py
+++ b/src/small_dis_example.py
@@ -1,0 +1,48 @@
+# This shows how to run the disassembler
+
+from asm6502 import asm6502
+from dis6502 import dis6502
+
+thecode = """
+        ORG  $100
+start:
+        LDA #$10
+        LDX #$00
+loop:
+        STA $1000,x
+        INX
+        SBC #$01
+        BPL loop
+        RTS
+"""
+
+lines = thecode.splitlines()
+
+a = asm6502()
+(lst,sym) = a.assemble(lines)
+# inspect output
+for line in lst:
+    print(line)
+print()
+for symbol in sym:
+    print(symbol)
+print()
+a.print_object_code()
+
+# Now work backwards, but make life hard by using an empty symbol table
+d = dis6502(a.object_code, {})
+# Pass 1 - build symbol table
+z = d.disassemble_region(0x100, 13, gen_symbols=True)
+# Need this to make the generator run, even though we ignore the output
+list(z)
+# Build data structure
+d.build_symbols_xref()
+# Pass 2: and output..
+z = d.disassemble_region(0x100, 13)
+for line in list(z):
+    print (line)
+
+print()
+for sym in d.symbols:
+    print(f"{sym:10s} = ${d.symbols[sym]:04X}")
+

--- a/src/test_assemble_in_two_places.py
+++ b/src/test_assemble_in_two_places.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 from asm6502 import asm6502
 a = asm6502(debug=0)
 lines = [' ORG $1000', ' NOP', ' LDA #$20', 'here: NOP', '  DB 10,11,12,13', '  RTS']

--- a/src/test_show_all_opcodes.py
+++ b/src/test_show_all_opcodes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import asm6502
 


### PR DESCRIPTION
* cope with illegal/non-existent instructions (generate DB with $byte and ASCII code in a comment)
* use the symbol table to annotate arguments as well as annotating into the label field (also useful when using the disassembler with the simulator)
* break out the symbol indexing into a separate routine so that the user can manipulate the symbol table and then rebuild the data structure.
* add an option to allow the disassembler to create entries in the symbol table. This isn't useful with the simulator but is useful 'standalone' where the disassembler can be called twice: first time it populates the symbol table and the output is discarded, second time the symbols are annotated onto the output
* Added example and revised the README

And some asm6502 tweaks:
* Allow optional offset to print_object_code
* Add new load_object_code to load from hex dump (with optional offset)
* Add optional switch to print_object_code that changes the format to canonical hexdump (spacing, and addition of ASCII where printable)